### PR TITLE
perf: i wanna go fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# php-daydifference
+
+A simple php tool to help you calculate the number of days between two given dates, while also giving you the ability to factor in excluded dates.
+
+Excluded dates can be:
+- a day of the week (ie: Weekends)
+- a specific date (ie: 2022-12-25)
+- a repeating date (ie: *-01-01)
+
+## Example usage
+
+A simple use case of this would be to determine how many work days there are for a given date range.
+
+```php
+$startDate = new DateTime('2022-01-01');
+$endDate = new DateTime('2022-02-01');
+$workDays = [1, 2, 3, 4, 5]; // 0 = sunday, 1 = monday, etc.
+$holidays = [
+  '*-01-01',
+  '2022-01-03',
+];
+
+$init = new DayDifference($startDate, $endDate, $workDays, $holidays);
+$dayDifference = $init->difference();
+```
+
+## Contributing
+
+This package doesn't get much activity so I don't have CI setup for this. Please ensure all commits pass:
+
+- `composer standards`
+- `composer static`
+- `composer test`
+
+You can run `composer standards:fix` to automatically adhere the code to the standard.

--- a/spec/DayDifference.spec.php
+++ b/spec/DayDifference.spec.php
@@ -114,8 +114,14 @@ describe('DayDifference', function() {
             '2020-10-10',
         ];
 
-        for ($i = 1; $i <= 1000; $i++) {
+        for ($i = 1; $i <= 3000; $i++) {
             expect(getDiff($startDate, $endDate, [0, 1, 2, 3, 4, 5, 6], $holidays))->toBe(365 - count($holidays));
+        }
+        for ($i = 1; $i <= 3000; $i++) {
+            expect(getDiff($startDate, $endDate, [0, 1, 2, 3, 4, 5, 6], []))->toBe(365);
+        }
+        for ($i = 1; $i <= 3000; $i++) {
+            expect(getDiff($startDate, $endDate, [2], [$holidays[0]]))->toBe(52);
         }
     });
 });


### PR DESCRIPTION
## Background

I wanted to see if there was a way we could eek out some more performance out of this script.

## What was done

To do this, I first created a stress test, where it ran 9000 comparison of dates that spanned a full year.

After adding the stress test, I ran the suite many times on my laptop, the last three are shown in the screenshot below. All results were within a few tenths of a second of that.

I then refactored the main `findDifference()` function to:
- Set the starting count at the full number of days between the two dates. This way, we're only modifying the variable if we come across an excluded date.
- The above also allows us to bail early if there are no exclusions.
- Getting a date format from an integer can be somewhat "expensive" when ran multiple times per iteration. I've pulled this into one function call & then parse the response from it.
- `[...] = explode(...)` the way I have is significantly faster than calling `mb_substr(...)` three times.
- Helper functions have been removed to reduce function call overhead
- When a date is skipped we can now short circuit out the condition and update our `$totalDays`

## A picture is worth 1000 words
![Screenshot_20220204_150608](https://user-images.githubusercontent.com/18272064/152597697-948ab9e2-617e-47fc-a114-8b1ab4ebd463.png)
* left = before. right = after